### PR TITLE
chore: update jscom_ice theme to v1.2.0

### DIFF
--- a/website/Gemfile
+++ b/website/Gemfile
@@ -8,6 +8,6 @@ gem "jekyll", "~> 4.3.2"
 
 group :jekyll_plugins do
   # jscom theme
-  gem "jscom_ice", '~> 1.1.0'
+  gem "jscom_ice", '~> 1.2.0'
 
 end

--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -1,8 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.8.8)
+      public_suffix (>= 2.0.2, < 8.0)
     bigdecimal (3.3.1)
     colorator (1.1.0)
     concurrent-ruby (1.3.5)
@@ -12,7 +12,7 @@ GEM
     eventmachine (1.2.7)
     ffi (1.17.2-arm64-darwin)
     forwardable-extended (2.6.0)
-    google-protobuf (4.33.0-arm64-darwin)
+    google-protobuf (4.33.1-arm64-darwin)
       bigdecimal
       rake (>= 13)
     http_parser.rb (0.8.0)
@@ -44,7 +44,7 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    jscom_ice (1.1.0)
+    jscom_ice (1.2.0)
       jekyll (~> 4.3)
       jekyll-compose (~> 0.12)
       jekyll-feed (~> 0.17)
@@ -60,20 +60,20 @@ GEM
     mercenary (0.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (6.0.2)
-    rake (13.3.0)
+    public_suffix (7.0.0)
+    rake (13.3.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     rexml (3.4.4)
     rouge (4.6.1)
     safe_yaml (1.0.5)
-    sass-embedded (1.93.2-arm64-darwin)
+    sass-embedded (1.94.2-arm64-darwin)
       google-protobuf (~> 4.31)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.6.0)
-    webrick (1.9.1)
+    webrick (1.9.2)
 
 PLATFORMS
   arm64-darwin-21
@@ -81,7 +81,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 4.3.2)
-  jscom_ice (~> 1.1.0)
+  jscom_ice (~> 1.2.0)
 
 BUNDLED WITH
    2.2.3


### PR DESCRIPTION
## Summary
- Updates jscom_ice theme from v1.1.0 to v1.2.0
- Adds click-to-expand image modal for post images

## Test plan
- [ ] Verify image modal works on stage.johnsosoka.com
- [ ] Test on mobile viewport
- [ ] Test escape key and click-outside-to-close