### PR TITLE
ci: add sosoka-ops project board automation

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,15 @@
+name: Add to sosoka-ops
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1
+        with:
+          project-url: https://github.com/users/johnsosoka/projects/1
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically adds new issues and PRs to the [sosoka-ops](https://github.com/users/johnsosoka/projects/1) project board.

**What it does:**
- Triggers on new issues and PRs
- Uses `actions/add-to-project@v1` to add the item to sosoka-ops
- Uses the `ADD_TO_PROJECT_PAT` secret (already configured)

**What it does NOT do:**
- Does not set fields (domain, agent, priority) — those are set manually or by agents
- Does not affect existing issues
- Does not modify the issue/PR itself